### PR TITLE
Check Auth::user in Role Middleware

### DIFF
--- a/app/Http/Middleware/RolesMiddleware.php
+++ b/app/Http/Middleware/RolesMiddleware.php
@@ -19,6 +19,9 @@ class RolesMiddleware
     public function handle($request, Closure $next, $requiredRole)
     {
         $model = Role::where('name', $requiredRole)->first();
+        if (empty(Auth::user())) {
+            throw new \Exception('User not logged in.');
+        }
 
         if (!is_null($model) && $model->is_active && Auth::user()->hasRole($model->_id)) {
             return $next($request);

--- a/tests/app/Http/Middleware/RoleMiddlewareTest.php
+++ b/tests/app/Http/Middleware/RoleMiddlewareTest.php
@@ -311,4 +311,12 @@ class RoleMiddlewareTest extends TestCase
         $users = json_decode($this->response->getContent());
         $this->assertEquals('5FFA95F4-5EB4-46FB-94F1-F2B27254725B', $users[0]->_id);
     }
+
+    public function testRequestWithoutLogin()
+    {
+        $this->post('/logout');
+        $this->get('/roles');
+        $result = json_decode($this->response->getContent());
+        $this->assertEquals('User not logged in.', $result->error);
+    }
 }


### PR DESCRIPTION
Role middleware was throwing a nasty null exception if a route was accessed by an unauthenticated actor. This handles it more gracefully

@darrynten 