### PR TITLE
Roles returned on getSelf

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -42,7 +42,7 @@ class UserController extends Controller
     {
         $userId = Auth::user()->_id;
 
-        $user = User::where('_id', $userId)->first();
+        $user = User::where('_id', $userId)->with('roles:_id,name')->first();
 
         return response()->json($user);
     }

--- a/tests/app/Http/UserControllerTest.php
+++ b/tests/app/Http/UserControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\User;
+use Illuminate\Database\Eloquent\Collection;
 use Laravel\Lumen\Testing\DatabaseMigrations;
 use Laravel\Lumen\Testing\DatabaseTransactions;
 
@@ -40,7 +41,7 @@ class UserControllerTest extends TestCase
         $resultObject = json_decode($this->response->getContent());
         $resultArray = json_decode($this->response->getContent(), true);
 
-        $this->assertEquals(7, count($resultArray));
+        $this->assertEquals(8, count($resultArray));
 
         // Should have username `user`
         $this->assertEquals('user', $resultObject->username);
@@ -48,8 +49,22 @@ class UserControllerTest extends TestCase
         // Should have an email
         $this->assertEquals('developer@example.com', $resultObject->email);
 
+        // Has no role
+        $this->assertEquals(0, count($resultArray['roles']));
+
         // Response should be a 200
         $this->assertEquals('200', $this->response->status());
+
+        // Test with admin user to check roles in response
+        $adminUser = User::where('_id', '5FFA95F4-5EB4-46FB-94F1-F2B27254725B')->first();
+        $this->actingAs($adminUser)->get('/api/me');
+        $result = json_decode($this->response->getContent());
+        $this->assertObjectHasAttribute('roles', $result);
+
+        $roles = new Collection($result->roles);
+
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue($roles->contains('name', 'admin'));
     }
 
     public function testGetEmptyUser()


### PR DESCRIPTION
User should be able to view their own roles
Added `roles` to returned user fields _only_ for getSelf
Tests included